### PR TITLE
[Feature]: Computed Properties for CalendarModel.Day for RangeType and DateType Calculations

### DIFF
--- a/Sources/OBCalendar/Examples/DemoCalendar.swift
+++ b/Sources/OBCalendar/Examples/DemoCalendar.swift
@@ -344,7 +344,13 @@ struct DemoCalendar: View {
                     )
                 }
             } else {
-                Color.clear
+                if model.isInRangePreviousMonth {
+                    Color.red
+                } else if model.isInRangeNextMonth {
+                    Color.green
+                } else {
+                    Color.blue
+                }
             }
         }
     }

--- a/Sources/OBCalendar/Model/CalendarModel.swift
+++ b/Sources/OBCalendar/Model/CalendarModel.swift
@@ -27,14 +27,71 @@ public enum CalendarModel {
             case currentMonth
         }
         
-        public enum RangeType {
+        public enum RangeType: Equatable {
             case outOfRange(DateType)
             case insideRange(DateType)
+            
+            var dateType: DateType {
+                switch self {
+                case .outOfRange(let dateType):
+                    dateType
+                case .insideRange(let dateType):
+                    dateType
+                }
+            }
+            
+            public var isOutOfRange: Bool {
+                switch self {
+                case .outOfRange:
+                    true
+                case .insideRange:
+                    false
+                }
+            }
+            
+            public var isInsideRange: Bool {
+                switch self {
+                case .outOfRange:
+                    false
+                case .insideRange:
+                    true
+                }
+            }
         }
         
         public let day: Int
         public let date: Date
         public let rangeType: RangeType
+        
+        public var isCurrentMonth: Bool {
+            rangeType.dateType == .currentMonth
+        }
+        
+        /// isCurrentMonth && insideRange
+        public var isInRangeCurrentMonth: Bool {
+            rangeType.dateType == .currentMonth
+            && rangeType.isInsideRange
+        }
+        
+        public var isPreviousMonth: Bool {
+            rangeType.dateType == .previousMonth
+        }
+        
+        /// isPreviousMonth && insideRange
+        public var isInRangePreviousMonth: Bool {
+            rangeType.dateType == .previousMonth
+            && rangeType.isInsideRange
+        }
+        
+        public var isNextMonth: Bool {
+            rangeType.dateType == .nextMonth
+        }
+        
+        /// isNextMonth && insideRange
+        public var isInRangeNextMonth: Bool {
+            rangeType.dateType == .nextMonth
+            && rangeType.isInsideRange
+        }
     }
 }
 

--- a/Sources/OBCalendar/Model/CalendarModel.swift
+++ b/Sources/OBCalendar/Model/CalendarModel.swift
@@ -33,9 +33,7 @@ public enum CalendarModel {
             
             var dateType: DateType {
                 switch self {
-                case .outOfRange(let dateType):
-                    dateType
-                case .insideRange(let dateType):
+                case .outOfRange(let dateType), .insideRange(let dateType):
                     dateType
                 }
             }

--- a/Sources/OBCalendar/Utility/CalendarModelBuilder.swift
+++ b/Sources/OBCalendar/Utility/CalendarModelBuilder.swift
@@ -84,21 +84,21 @@ public enum CalendarModelBuilder {
 }
 
 //MARK: - Private helpers
-extension CalendarModelBuilder {
+private extension CalendarModelBuilder {
     
-    private static func getBeginningPlaceholderCount(calendar: Calendar, totalWeekdayCount: Int, targetDate: Date) -> Int {
+    static func getBeginningPlaceholderCount(calendar: Calendar, totalWeekdayCount: Int, targetDate: Date) -> Int {
         let currentWeekday = calendar.component(.weekday, from: targetDate)
         let firstWeekday = calendar.firstWeekday
         return (currentWeekday - firstWeekday + totalWeekdayCount) % totalWeekdayCount
     }
     
-    private static func getEndingPlaceholderCount(calendar: Calendar, totalWeekdayCount: Int, targetDate: Date) -> Int {
+    static func getEndingPlaceholderCount(calendar: Calendar, totalWeekdayCount: Int, targetDate: Date) -> Int {
         let targetWeekday = calendar.component(.weekday, from: targetDate)
         let firstWeekday = calendar.firstWeekday
         return (totalWeekdayCount - targetWeekday + firstWeekday - 1) % totalWeekdayCount
     }
     
-    private static func addBeginningPlaceholder(
+    static func addBeginningPlaceholder(
         calendar: Calendar,
         totalWeekdayCount: Int,
         targetDate: Date,
@@ -129,7 +129,7 @@ extension CalendarModelBuilder {
         }
     }
     
-    private static func addEndingPlaceholder(
+    static func addEndingPlaceholder(
         calendar: Calendar,
         totalWeekdayCount: Int,
         targetDate: Date,


### PR DESCRIPTION
**FEATURE**
New computed properties have been added to `CalendarModel.Day` and `RangeType` and `DateType` enums. 
The new properties allow you to check if the day model is inside the desired range (like `currentMonth`, `nextMonth`, etc.) with cleaner syntax compared to enum case comparisons.

Direct conditional statement: 
```swift
if case .insideRange(.currentMonth) = dayModel.rangeType
```
New way:
```swift
if dayModel.isInRangeCurrentMonth
```
